### PR TITLE
Write to console instead of file, to leverage GHA native logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     description: 'The project id'
   branch_name:
-    required: true
+    required: false
     description: 'The branch name'
   api_key:
     description: 'The Neon API key'

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     description: 'The project id'
   branch_name:
-    required: false
+    required: true
     description: 'The branch name'
   api_key:
     description: 'The Neon API key'
@@ -25,7 +25,7 @@ inputs:
     description: 'Use prisma or not'
     default: 'false'
   parent:
-    description: 'The parent branch name or id or LSN or timestamp . By default the primary branch is used'
+    description: 'The parent branch name or id or LSN or timestamp. By default the primary branch is used'
   suspend_timeout:
     description: >
       Duration of inactivity in seconds after which the compute endpoint is
@@ -37,13 +37,13 @@ outputs:
     description: 'New branch DATABASE_URL'
     value: ${{ steps.create-branch.outputs.db_url }}
   db_url_with_pooler:
-    description: 'New branch DATABASE_URL'
+    description: 'New branch DATABASE_URL with pooling enabled'
     value: ${{ steps.create-branch.outputs.db_url_with_pooler }}
   host:
     description: 'New branch host'
     value: ${{ steps.create-branch.outputs.host }}
   host_with_pooler:
-    description: 'New branch pooled host'
+    description: 'New branch host with pooling enabled'
     value: ${{ steps.create-branch.outputs.host_with_pooler }}
   branch_id:
     description: 'New branch id'
@@ -69,11 +69,8 @@ runs:
           --output json \
           2> branch_err > branch_out || true
 
-        echo "branch create out:\n" >> debug.log
-        cat branch_out >> debug.log
-        echo "\nbranch create err:\n" >> debug.log
-        cat branch_err >> debug.log
-        echo "\n" >> debug.log
+        echo "branch create out:\n${branch_out}"
+        echo "branch create err:\n${branch_err}"
 
         if [[ $(cat branch_err) == *"already exists"* ]]; then
 
@@ -81,7 +78,7 @@ runs:
           branch_id=$(neonctl branches list --project-id ${{ inputs.project_id }} -o json \
               | jq -r '.[] | select(.name == "${{ inputs.branch_name }}") | .id')
 
-          echo "branch exists, branch id: ${branch_id}\n" >> debug.log
+          echo "branch exists, branch id: ${branch_id}"
 
           echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
           NEON_CS=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --prisma ${{ inputs.prisma }} --extended -o json)
@@ -101,7 +98,7 @@ runs:
             exit 1
           fi
 
-          echo "branch doesn't exist, branch id: ${branch_id}\n" >> debug.log
+          echo "branch doesn't exist, branch id: ${branch_id}"
 
           echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
           NEON_CS=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --prisma ${{ inputs.prisma }} --extended -o json)
@@ -115,9 +112,3 @@ runs:
         echo "db_url_with_pooler=${DB_URL_WITH_POOLER}" >> $GITHUB_OUTPUT
         echo "host=${DB_HOST}" >> $GITHUB_OUTPUT
         echo "host_with_pooler=${DB_HOST_WITH_POOLER}" >> $GITHUB_OUTPUT
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: Create branch log
-        path: debug.log
-

--- a/action.yml
+++ b/action.yml
@@ -69,8 +69,10 @@ runs:
           --output json \
           2> branch_err > branch_out || true
 
-        echo "branch create out:\n${branch_out}"
-        echo "branch create err:\n${branch_err}"
+        echo "branch create out:"
+        cat branch_out
+        echo "branch create err:"
+        cat branch_err
 
         if [[ $(cat branch_err) == *"already exists"* ]]; then
 


### PR DESCRIPTION
## Background

- I recently started using this action and noticed the run logs don't have meaningful output:
<img width="1332" alt="image" src="https://github.com/neondatabase/create-branch-action/assets/2145098/a906c634-7bf7-41ff-8cda-6e85c54faf01">

- To see the logs, I need to navigate back to a run summary, download an artifact, unzip, and view:
<img width="701" alt="image" src="https://github.com/neondatabase/create-branch-action/assets/2145098/60f9787b-07aa-48af-8cfe-52442f4877c2">

![image](https://github.com/neondatabase/create-branch-action/assets/2145098/ac6e1f73-32b0-4ad9-b2be-dd47d889b0e3)

- Afterwards, I need to delete the zip + txt file from my local machine

## Proposal

- This PR proposes inlining the logs instead, so they are immediately useful and searchable within the native GHA log UI:
<img width="1329" alt="image" src="https://github.com/neondatabase/create-branch-action/assets/2145098/1066d0f1-aa18-4c05-bd6c-d29c1fa5a870">

- Added benefit of removing a dependency on the upload-artifacts action