### PR TITLE
feat: output password

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ outputs:
     description: 'New branch DATABASE_URL'
     value: ${{ steps.create-branch.outputs.db_url }}
   db_url_with_pooler:
-    description: 'New branch DATABASE_URL with pooling enabled'
+    description: 'New branch DATABASE_URL'
     value: ${{ steps.create-branch.outputs.db_url_with_pooler }}
   host:
     description: 'New branch host'
     value: ${{ steps.create-branch.outputs.host }}
   host_with_pooler:
-    description: 'New branch host with pooling enabled'
+    description: 'New branch pooled host'
     value: ${{ steps.create-branch.outputs.host_with_pooler }}
   branch_id:
     description: 'New branch id'
     value: ${{ steps.create-branch.outputs.branch_id }}
+  password:
+    description: 'Password for connecting to the new branch database with the input username'
+    value: ${{ steps.create-branch.outputs.password }}
 ```
 
 ## How to set up the NEON_API_KEY

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ outputs:
     description: 'New branch DATABASE_URL'
     value: ${{ steps.create-branch.outputs.db_url }}
   db_url_with_pooler:
-    description: 'New branch DATABASE_URL'
+    description: 'New branch DATABASE_URL with pooling enabled'
     value: ${{ steps.create-branch.outputs.db_url_with_pooler }}
   host:
     description: 'New branch host'
     value: ${{ steps.create-branch.outputs.host }}
   host_with_pooler:
-    description: 'New branch pooled host'
+    description: 'New branch host with pooling enabled'
     value: ${{ steps.create-branch.outputs.host_with_pooler }}
   branch_id:
     description: 'New branch id'

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ outputs:
   branch_id:
     description: 'New branch id'
     value: ${{ steps.create-branch.outputs.branch_id }}
+  password:
+    description: 'Password for connecting to the new branch database with the input username'
+    value: ${{ steps.create-branch.outputs.password }}
 
 runs:
   using: 'composite'
@@ -82,11 +85,13 @@ runs:
               | jq -r '.[] | select(.name == "${{ inputs.branch_name }}") | .id')
 
           echo "branch exists, branch id: ${branch_id}\n" >> debug.log
-
           echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
+
           NEON_CS=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL=$(echo $NEON_CS | jq -r '.connection_string')
           DB_HOST=$(echo $NEON_CS | jq -r '.host')
+          DB_PASSWORD=$(echo $NEON_CS | jq -r '.password')
+
           NEON_CS_POOLER=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --pooled --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.connection_string')
           DB_HOST_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.host')
@@ -102,17 +107,20 @@ runs:
           fi
 
           echo "branch doesn't exist, branch id: ${branch_id}\n" >> debug.log
-
           echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
+
           NEON_CS=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL=$(echo $NEON_CS | jq -r '.connection_string')
           DB_HOST=$(echo $NEON_CS | jq -r '.host')
+          DB_PASSWORD=$(echo $NEON_CS | jq -r '.password')
+
           NEON_CS_POOLER=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --pooled --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.connection_string')
           DB_HOST_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.host')
         fi
         echo "db_url=${DB_URL}" >> $GITHUB_OUTPUT
         echo "db_url_with_pooler=${DB_URL_WITH_POOLER}" >> $GITHUB_OUTPUT
+        echo "password=${DB_PASSWORD}" >> $GITHUB_OUTPUT
         echo "host=${DB_HOST}" >> $GITHUB_OUTPUT
         echo "host_with_pooler=${DB_HOST_WITH_POOLER}" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v3
@@ -120,4 +128,3 @@ runs:
       with:
         name: Create branch log
         path: debug.log
-

--- a/action.yml
+++ b/action.yml
@@ -85,13 +85,12 @@ runs:
               | jq -r '.[] | select(.name == "${{ inputs.branch_name }}") | .id')
 
           echo "branch exists, branch id: ${branch_id}\n" >> debug.log
-          echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
 
+          echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
           NEON_CS=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL=$(echo $NEON_CS | jq -r '.connection_string')
           DB_HOST=$(echo $NEON_CS | jq -r '.host')
           DB_PASSWORD=$(echo $NEON_CS | jq -r '.password')
-
           NEON_CS_POOLER=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --pooled --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.connection_string')
           DB_HOST_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.host')
@@ -107,13 +106,12 @@ runs:
           fi
 
           echo "branch doesn't exist, branch id: ${branch_id}\n" >> debug.log
-          echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
 
+          echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
           NEON_CS=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL=$(echo $NEON_CS | jq -r '.connection_string')
           DB_HOST=$(echo $NEON_CS | jq -r '.host')
           DB_PASSWORD=$(echo $NEON_CS | jq -r '.password')
-
           NEON_CS_POOLER=$(neonctl cs ${branch_id} --project-id ${{ inputs.project_id }} --role-name ${{ inputs.username }} --database-name ${{ inputs.database }} --pooled --prisma ${{ inputs.prisma }} --extended -o json)
           DB_URL_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.connection_string')
           DB_HOST_WITH_POOLER=$(echo $NEON_CS_POOLER | jq -r '.host')
@@ -128,3 +126,4 @@ runs:
       with:
         name: Create branch log
         path: debug.log
+


### PR DESCRIPTION
## Background
- My team uses [Flyway](https://flywaydb.org/) for database migrations
- Flyway uses the JDBC postgres driver, which doesn't work with the output `db_url`
   - instead of `postgres://USER:PASS@HOST/DB`, it's `jdbc:postgresql://HOST/DB?user=USER&password=PASS`

## Proposal
- This PR adds `password` as an output, so that we can run Flyway migrations (or any other non-psql based migration system) after `create-branch-action`

## Alterantives
- I could instead store a separate `secrets.NEON_PASSWORD`, but I'd prefer to only need `secrets.NEON_API_KEY` given that `neonctl` returns everything I need
- I could use `neonctl` directly instead of this action