### PR TITLE
misc: parameterise optional neon host from inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   api_key:
     description: 'The Neon API key'
     required: true
+  api_host:
+    description: 'The Neon API Host'
+    default: 'https://console.neon.tech/api/v2'
   username:
     description: 'The db role name'
     required: true
@@ -65,6 +68,7 @@ runs:
     - name: Create new Neon branch
       env:
         NEON_API_KEY: ${{ inputs.api_key }}
+        NEON_API_HOST: ${{ inputs.api_host }}
         # Annotation data, extracted from github.* variables to be displayed in the Console.
         # Must be moved to env due to security recommendations.
         # Action can be triggered by different events (push, pull_request, for example).


### PR DESCRIPTION
We can not use and test `create-branch-action` workflow in any environment other than production. 

Parameterizing `api_host` and setting the environment variable `NEON_API_HOST` make it possible to connect to other environments

relates: https://github.com/neondatabase/delete-branch-action/pull/20