### PR TITLE
Fix: create branch GH action works but throws an error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
         echo "::add-mask::$(cat branch_out | jq -r '.connection_uris[0].connection_parameters.password')"
         echo "branch create out:"
         cat branch_out
-        if [[ $(cat branch_err) ]]; then
+        if [[ -f branch_err ]]; then
           echo "branch create err:"
           cat branch_err
         fi

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
         echo "::add-mask::$(cat branch_out | jq -r '.connection_uris[0].connection_parameters.password')"
         echo "branch create out:"
         cat branch_out
-        if [[ -f branch_err ]]; then
+        if [[ $(cat branch_err) ]]; then
           echo "branch create err:"
           cat branch_err
         fi

--- a/action.yml
+++ b/action.yml
@@ -115,8 +115,10 @@ runs:
         echo "::add-mask::$(cat branch_out | jq -r '.connection_uris[0].connection_parameters.password')"
         echo "branch create out:"
         cat branch_out
-        echo "branch create err:"
-        cat branch_err
+        if [[ $(cat branch_err) ]]; then
+          echo "branch create err:"
+          cat branch_err
+        fi
 
         if [[ $(cat branch_err) == *"already exists"* ]]; then
 

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
         echo "::add-mask::$(cat branch_out | jq -r '.connection_uris[0].connection_parameters.password')"
         echo "branch create out:"
         cat branch_out
-        if [[ $(cat branch_err) ]]; then
+        if [[ -s branch_err ]]; then
           echo "branch create err:"
           cat branch_err
         fi


### PR DESCRIPTION
resolves https://github.com/neondatabase/cloud/issues/17714

"branch create error" is printed only if there is non-empty error.
- [pipeline without error example](https://github.com/antelman107/recaptcha3/actions/runs/10993010149/job/30518650015)
- [pipeline with error example](https://github.com/antelman107/recaptcha3/actions/runs/10992954540)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling to display messages only when there are actual errors, enhancing clarity in output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->