### PR TITLE
deps: run package in post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "package:watch": "bun run package -- --watch",
     "prebuild": "sh ./scripts/generate-version.sh",
     "test": "vitest run",
-    "all": "bun run prebuild && bun run format:write && bun run lint && bun run test && bun run coverage && bun run package"
+    "all": "bun run prebuild && bun run format:write && bun run lint && bun run test && bun run coverage && bun run package",
+    "postinstall": "bun run package"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This will streamline the process of merging dependabot PRs as we previously required to checkout the PR and bundle the code manually, this adds the package step to the postinstall script which will run when each dependency is added or updated.