### PR TITLE
[dependabot/config] fix: enable dependabot for bun package lock files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,18 @@ updates:
         dependency-type: production
         update-types:
           - patch
+
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-development:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      npm-production:
+        dependency-type: production
+        update-types:
+          - patch


### PR DESCRIPTION
According to [our docs](https://github.com/neondatabase/create-branch-action/blob/main/docs/development.md), the repo relies on bun as package management tool.

While looking into dependabot reports I realized that findings are about npm/yarn-related lock files and bun.lock is not scanned at all. This change should fix it.