### PR TITLE
chore: harden CI workflows against supply chain attacks

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,9 @@ permissions: {}
 jobs:
   check-dist:
     name: Check dist/
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ permissions: {}
 jobs:
   test-typescript:
     name: TypeScript Tests
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       contents: read
 

--- a/.github/workflows/dependabot-auto-fix.yml
+++ b/.github/workflows/dependabot-auto-fix.yml
@@ -14,7 +14,9 @@ permissions: {}
 jobs:
   auto-package:
     name: Auto Package Dependabot PR
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     # Run on Dependabot PRs or manual triggers
     if:
       github.repository == github.event.pull_request.head.repo.full_name &&
@@ -30,7 +32,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            registry.npmjs.org:443
+            bun.sh:443
 
       - name: Checkout
         id: checkout
@@ -49,7 +58,11 @@ jobs:
           bun-version: latest
 
       - name: Install Dependencies
-        run: bun install
+        # --frozen-lockfile: install exactly what the proposed bun.lock says
+        # --ignore-scripts: block lifecycle scripts (postinstall etc.) from
+        # any dependency so a malicious Dependabot bump cannot execute code
+        # at install time under this job's contents:write token.
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run Packaging
         run: bun run all

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,9 @@ permissions: {}
 jobs:
   lint:
     name: Lint Codebase
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       contents: read
       packages: read

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "package:watch": "bun run package -- --watch",
     "prebuild": "sh ./scripts/generate-version.sh",
     "test": "vitest run",
-    "all": "bun run prebuild && bun run format:write && bun run lint && bun run test && bun run coverage && bun run package",
-    "postinstall": "bun run package"
+    "all": "bun run prebuild && bun run format:write && bun run lint && bun run test && bun run coverage && bun run package"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
- Drop postinstall script from package.json so `bun install` no longer re-runs the Rollup bundle automatically. Every workflow that needs dist/ rebuilt already calls `bun run bundle`/`bun run all` explicitly.
- dependabot-auto-fix.yml: install with --frozen-lockfile --ignore-scripts so a malicious package version proposed by a Dependabot bump cannot execute lifecycle code under this job's contents:write token.
- dependabot-auto-fix.yml: flip harden-runner from audit to block with an explicit endpoint allowlist for npm/github/bun.
- Move ci.yml, check-dist.yml, linter.yml, dependabot-auto-fix.yml to runs-on: neondatabase-protected-runner-group to match codeql-analysis and the rest of the neondatabase org.